### PR TITLE
Fixed crash when visiting anecdote page for created anecdote

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -104,7 +104,7 @@ const App = () => {
   const [notification, setNotification] = useState('')
 
   const addNew = (anecdote) => {
-    anecdote.id = (Math.random() * 10000).toFixed(0)
+    anecdote.id = Math.round(Math.random() * 10000)
     setAnecdotes(anecdotes.concat(anecdote))
   }
 


### PR DESCRIPTION
# What has changed

Generated ids for new anecdotes now use 
```js 
Math.round(Math.random() * 10000)
```
with type Number, instead of
```js
(Math.random() * 10000).toFixed(0)
```
with type String, so that these ids match the type of those in the initial state.

# What this fixes

This prevents TypeErrors and thus the page for the anecdote not showing completely, as the given function for finding anecdotes by id
```js
const anecdoteById = id => anecdotes.find(a => a.id === id)
```
does not match consistently across initial state and added state. This mostly notably happens when the id parameter of this function is found using the useMatch hook in a similar fashion to the course notes:
```js
const match = useMatch('/notes/:id')
const note = match 
  ? notes.find(note => note.id === Number(match.params.id))
  : null
```